### PR TITLE
Use Lean to generate C addition function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+main
+Export.c
+lakefile.toml
+.lake/
+*.olean
+*.a
+*.o
+*.so

--- a/Export.lean
+++ b/Export.lean
@@ -1,6 +1,3 @@
-import Lean
-open Lean
-
-@[extern "lean_add"]
+@[export lean_add]
 def add (x y : UInt32) : UInt32 :=
   x + y

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -1,11 +1,8 @@
 import Lake
-import Lean.Elab.Facet
 open Lake DSL
 
 package exportExample
 
 @[default_target]
-lean_lib Export where
-  precompileModules := true
-  nativeFacets := fun _ => #[.sharedLib]
+lean_lib Export
 

--- a/main.c
+++ b/main.c
@@ -1,0 +1,20 @@
+#include <lean/lean.h>
+#include <stdio.h>
+
+uint32_t lean_add(uint32_t, uint32_t);
+lean_object* initialize_Export(uint8_t, lean_object*);
+void lean_initialize_runtime_module();
+
+int main(int argc, char **argv) {
+    lean_initialize_runtime_module();
+    lean_object* res = initialize_Export(1, lean_io_mk_world());
+    if (lean_io_result_is_error(res)) {
+        lean_io_result_show_error(res);
+        lean_dec_ref(res);
+        return 1;
+    }
+    lean_dec_ref(res);
+    uint32_t result = lean_add(2, 3);
+    printf("%u\n", result);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- export Lean `add` function as C symbol `lean_add`
- simplify Lake configuration and add C demo calling Lean code

## Testing
- `lake build`
- `lean -c Export.c Export.lean`
- `gcc main.c Export.c -I$LEAN_PREFIX/include -L$LEAN_PREFIX/lib/lean -lleanshared -lstdc++ -lgmp -ldl -pthread -lm -o main`
- `LD_LIBRARY_PATH=$LEAN_PREFIX/lib/lean:$LD_LIBRARY_PATH ./main`


------
https://chatgpt.com/codex/tasks/task_e_68912fda90848322947303f058f2ad41